### PR TITLE
Updating readme files and correcting plugin header information

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,30 @@
+# Wikiblock - Gutenberg Block to embed Wikiloc trails
+
+This repository contains the source code of the Wikibloc WordPress plugin. 
+
+## Development
+
+To start developing with this plugin, please run the following command on the repository directory:
+
+`npm run start`
+
+You can use the [WordPress Development Enviroment](https://developer.wordpress.org/block-editor/getting-started/devenv/) by running the following command on the plugin directory: 
+
+`wp-env start`
+
+## Plugin Build
+
+Please, run the following commands to build a ZIP file containing the plugin files in order to install it on any WordPress site:
+
+1. Run the asset build: `npm run build`
+2. Run the zip build: `npm run plugin-zip`
+
+Once the commands are executed, the file `wikiblock.zip` will be placed on the repository directory.
+
+## Contribute
+
+Feel free to open any issue or a Pull Request to the GitHub repository.
+
+## License 
+
+Wikiblock is licensed under the GNU General Public License v2 (or later).

--- a/readme.txt
+++ b/readme.txt
@@ -1,55 +1,26 @@
 === Wikiblock ===
 Contributors:      jartes
-Tags:              block
+Tags:              wikiloc, embed, map, blocks
 Tested up to:      5.9
 Stable tag:        0.1.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
-Example block written with ESNext standard and JSX support – build step required.
+An editor block to embed Wikiloc trails.
 
 == Description ==
 
-This is the long description. No limit, and you can use Markdown (as well as in the following sections).
-
-For backwards compatibility, if this section is missing, the full length of the short description will be used, and
-Markdown parsed.
+Embedding Wikiloc Trail is easier with the Wikiblock block! Once the plugin is installed and activated, the Wikiblock block will be available to easily share your Wikiloc trails.
 
 == Installation ==
 
-This section describes how to install the plugin and get it working.
-
-e.g.
-
 1. Upload the plugin files to the `/wp-content/plugins/wikiblock` directory, or install the plugin through the WordPress plugins screen directly.
-1. Activate the plugin through the 'Plugins' screen in WordPress
+2. Activate the plugin through the 'Plugins' screen in WordPress.
+3. Create or edit any page or post and add the "Wikiblock" block. 
+4. Enter the Trail URL to the block. 
 
-
-== Frequently Asked Questions ==
-
-= A question that someone might have =
-
-An answer to that question.
-
-= What about foo bar? =
-
-Answer to foo bar dilemma.
-
-== Screenshots ==
-
-1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
-the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets
-directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png`
-(or jpg, jpeg, gif).
-2. This is the second screen shot
 
 == Changelog ==
 
 = 0.1.0 =
-* Release
-
-== Arbitrary section ==
-
-You may provide arbitrary sections, in the same format as the ones above. This may be of use for extremely complicated
-plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
-"installation." Arbitrary sections will be shown below the built-in sections outlined above.
+* Initial release.

--- a/wikiblock.php
+++ b/wikiblock.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Plugin Name:       Wikiblock
- * Description:       Example block written with ESNext standard and JSX support – build step required.
+ * Description:       An editor block to embed Wikiloc trails.
  * Requires at least: 5.8
  * Requires PHP:      7.0
  * Version:           0.1.0
- * Author:            The WordPress Contributors
+ * Author:            jartes
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       wikiblock


### PR DESCRIPTION
### Description
This PR updates the readme files and corrects plugin header information.

### Changes in this PR
- Added a `readme.md` file for the GitHub repository.
- Updated the `readme.txt` with correct information. 
- Updated some plugin information headers from the `wikiblock.php` file. 

### Test instructions
- Check file `readme.md` is added correctly in the root folder with the correct plugin information.
- Take a look at the `readme.txt` file and check that it contains accurate information about the plugin.
- Check by going to **Plugins → Installed Plugins** that the plugin description is "An editor block to embed Wikiloc trails." and the author is "jartes".